### PR TITLE
Fix all open issues (#8–#14) + Lobsterfile lifecycle

### DIFF
--- a/src/backup.js
+++ b/src/backup.js
@@ -301,6 +301,12 @@ export async function runBackup(options) {
       }
     }
     
+    // Warn loudly if no Lobsterfile exists — this means restore can't rebuild the environment
+    const lobsterfileCheckPath = path.join(os.homedir(), '.openclaw', 'lobsterfile');
+    if (!fs.existsSync(lobsterfileCheckPath)) {
+      warnings.push('⚠️  No Lobsterfile found! Restore will only restore files — it cannot rebuild packages, services, or system configuration. Run lobster setup or create ~/.openclaw/lobsterfile manually.');
+    }
+
     // Generate manifests
     const internalManifest = generateInternalManifest();
     

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -155,6 +155,55 @@ export async function unwrapVaultKey(wrapped, wrappingKey) {
 }
 
 /**
+ * Wrap (encrypt) an age private key using AES-256-GCM with the vault key
+ * 
+ * The age private key is variable-length text (not a fixed 32 bytes like the vault key).
+ * Same AES-256-GCM approach but different AAD to prevent confusion with vault key wrapping.
+ * 
+ * @param {string} agePrivateKey - The AGE-SECRET-KEY-... string
+ * @param {Buffer} vaultKey - The 256-bit vault key
+ * @returns {Buffer} IV (12) + encrypted data (variable) + auth tag (16)
+ */
+export function wrapAgePrivateKey(agePrivateKey, vaultKey) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', vaultKey, iv);
+  cipher.setAAD(Buffer.from('lobster-backup-age-private-key', 'utf8'));
+  
+  const plaintext = Buffer.from(agePrivateKey, 'utf8');
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  
+  return Buffer.concat([iv, encrypted, authTag]);
+}
+
+/**
+ * Unwrap (decrypt) an age private key using AES-256-GCM with the vault key
+ * @param {Buffer} wrapped - IV + encrypted data + auth tag
+ * @param {Buffer} vaultKey - The 256-bit vault key
+ * @returns {string} The decrypted AGE-SECRET-KEY-... string
+ */
+export function unwrapAgePrivateKey(wrapped, vaultKey) {
+  if (wrapped.length < 28) { // minimum: 12 IV + 0 data + 16 tag
+    throw new Error('Invalid wrapped age private key length');
+  }
+  
+  const iv = wrapped.subarray(0, 12);
+  const encrypted = wrapped.subarray(12, wrapped.length - 16);
+  const authTag = wrapped.subarray(wrapped.length - 16);
+  
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', vaultKey, iv);
+    decipher.setAuthTag(authTag);
+    decipher.setAAD(Buffer.from('lobster-backup-age-private-key', 'utf8'));
+    
+    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch (error) {
+    throw new Error('Failed to unwrap age private key: invalid vault key or corrupted data');
+  }
+}
+
+/**
  * Encrypt an archive using age with multiple recipients
  * @param {Object} options - Encryption options
  * @param {string} options.inputPath - Path to input file to encrypt

--- a/src/lobsterfile.js
+++ b/src/lobsterfile.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { execSync } from 'node:child_process';
 
 /**
@@ -49,6 +50,75 @@ export function validateLobsterfile(content) {
       error: error.message 
     };
   }
+}
+
+/**
+ * Initialize a new Lobsterfile at the given path.
+ * Creates the file with a shebang + header. Optionally seeds from lobsterfile.seed.
+ * 
+ * This is the missing piece — setup generated lobsterfile.seed but never promoted
+ * it to the actual Lobsterfile. Without this, the backup silently skips the
+ * Lobsterfile and restore can't rebuild the environment.
+ * 
+ * @param {string} lobsterfilePath - Path to create the Lobsterfile
+ * @param {object} [options] - Options
+ * @param {string} [options.seedPath] - Path to lobsterfile.seed to incorporate
+ * @param {boolean} [options.force] - Overwrite existing Lobsterfile
+ * @returns {object} { created: boolean, path: string, seeded: boolean }
+ */
+export function initLobsterfile(lobsterfilePath, options = {}) {
+  const { seedPath, force = false } = options;
+  
+  // Don't overwrite existing Lobsterfile unless forced
+  if (fs.existsSync(lobsterfilePath) && !force) {
+    return { created: false, path: lobsterfilePath, seeded: false, reason: 'already exists' };
+  }
+  
+  let content = '#!/bin/bash\n';
+  content += '# Lobsterfile — system environment rebuild script\n';
+  content += '# Maintained in real-time by the agent. Updated whenever system state changes.\n';
+  content += '# This file is turned into a bash script for automated restore.\n';
+  content += '#\n';
+  content += '# Rules:\n';
+  content += '#   - Prefix commands requiring root with sudo\n';
+  content += '#   - Write every step idempotently\n';
+  content += '#   - Use {{VARIABLE}} placeholders for environment-specific values\n';
+  content += '\n';
+  
+  let seeded = false;
+  
+  // If a seed file exists, incorporate its content (minus the header)
+  if (seedPath && fs.existsSync(seedPath)) {
+    const seedContent = fs.readFileSync(seedPath, 'utf-8');
+    const seedLines = seedContent.split('\n');
+    // Skip the seed header (lines starting with # at the top)
+    let headerDone = false;
+    const seedBody = seedLines.filter(line => {
+      if (!headerDone && (line.startsWith('#') || line.trim() === '')) {
+        if (line.trim() === '') headerDone = true;
+        return false;
+      }
+      headerDone = true;
+      return true;
+    }).join('\n');
+    
+    if (seedBody.trim()) {
+      content += '# --- Seeded from environment audit ---\n';
+      content += seedBody + '\n';
+      content += '# --- End seed ---\n\n';
+      seeded = true;
+    }
+  }
+  
+  // Ensure parent directory exists
+  const dir = path.dirname(lobsterfilePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  
+  fs.writeFileSync(lobsterfilePath, content, { mode: 0o644 });
+  
+  return { created: true, path: lobsterfilePath, seeded };
 }
 
 /**

--- a/src/lobsterfile.js
+++ b/src/lobsterfile.js
@@ -91,16 +91,13 @@ export function initLobsterfile(lobsterfilePath, options = {}) {
   if (seedPath && fs.existsSync(seedPath)) {
     const seedContent = fs.readFileSync(seedPath, 'utf-8');
     const seedLines = seedContent.split('\n');
-    // Skip the seed header (lines starting with # at the top)
-    let headerDone = false;
-    const seedBody = seedLines.filter(line => {
-      if (!headerDone && (line.startsWith('#') || line.trim() === '')) {
-        if (line.trim() === '') headerDone = true;
-        return false;
-      }
-      headerDone = true;
-      return true;
-    }).join('\n');
+    // Skip the seed header: contiguous block of comment/blank lines at the top.
+    // Header ends at the first non-comment, non-blank line (an actual command).
+    let firstCommandIdx = seedLines.findIndex(line => 
+      line.trim() !== '' && !line.trim().startsWith('#')
+    );
+    if (firstCommandIdx === -1) firstCommandIdx = seedLines.length;
+    const seedBody = seedLines.slice(firstCommandIdx).join('\n');
     
     if (seedBody.trim()) {
       content += '# --- Seeded from environment audit ---\n';

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -81,7 +81,26 @@ function walkDirectory(dir, exclusions = []) {
 }
 
 /**
+ * Additional exclusion patterns for internal manifest
+ * These are added on top of DEFAULT_EXCLUSIONS when walking ~/.openclaw/
+ */
+const INTERNAL_EXTRA_EXCLUSIONS = [
+  'dist/',
+  'build/',
+  'venv/',
+  '.venv/',
+  '__pycache__/',
+  '*.pyc',
+  'lobster-backups/',  // Don't back up backups
+  'lobster-backup.lock',
+];
+
+/**
  * Generate internal manifest - files from ~/.openclaw/
+ * 
+ * Walks the ENTIRE ~/.openclaw/ directory tree, applying exclusions.
+ * The old allowlist approach silently dropped new workspace content from backups.
+ * 
  * @param {string} ocDir - Path to .openclaw directory (defaults to ~/.openclaw)
  * @param {object} config - Configuration with exclusions
  * @returns {Array} List of files to backup
@@ -91,43 +110,10 @@ export function generateInternalManifest(ocDir = null, config = {}) {
     ocDir = path.join(os.homedir(), '.openclaw');
   }
   
-  const exclusions = config.exclusions || [];
-  const files = [];
+  const exclusions = [...INTERNAL_EXTRA_EXCLUSIONS, ...(config.exclusions || [])];
   
-  // Specific paths to include
-  const specificPaths = [
-    'workspace/MEMORY.md',
-    'workspace/SOUL.md', 
-    'workspace/USER.md',
-    'workspace/IDENTITY.md',
-    'workspace/AGENTS.md',
-    'workspace/TOOLS.md',
-    'workspace/HEARTBEAT.md',
-    'openclaw.json',
-    'cron/jobs.json'
-  ];
-  
-  // Add specific paths if they exist
-  for (const relativePath of specificPaths) {
-    const fullPath = path.join(ocDir, relativePath);
-    if (fs.existsSync(fullPath) && !isExcluded(fullPath, exclusions)) {
-      files.push(fullPath);
-    }
-  }
-  
-  // Walk specific directories
-  const directories = [
-    'workspace/memory',
-    'skills',
-    'identity'
-  ];
-  
-  for (const dir of directories) {
-    const fullDir = path.join(ocDir, dir);
-    files.push(...walkDirectory(fullDir, exclusions));
-  }
-  
-  return files;
+  // Walk the entire ~/.openclaw/ tree with exclusions
+  return walkDirectory(ocDir, exclusions);
 }
 
 /**
@@ -254,12 +240,13 @@ export function detectGitRepo(dirPath) {
 export function generateGitCloneEntry(gitInfo) {
   const { remoteUrl, localPath, ref } = gitInfo;
   
+  // Quote paths for bash safety — spaces in paths are common
   let entry = `# Clone ${remoteUrl} to ${localPath}\n`;
-  entry += `git clone ${remoteUrl} ${localPath}\n`;
-  entry += `cd ${localPath}\n`;
+  entry += `git clone "${remoteUrl}" "${localPath}"\n`;
+  entry += `cd "${localPath}"\n`;
   
   if (ref) {
-    entry += `git checkout ${ref}\n`;
+    entry += `git checkout "${ref}"\n`;
   }
   
   return entry;

--- a/src/restore.js
+++ b/src/restore.js
@@ -254,17 +254,11 @@ export async function decryptBackup({ archivePath, credentialType, passphrase, r
 
     // Step 2: Unwrap the age private key using the vault key.
     // Full chain: passphrase → Argon2id → unwrap vault key → unwrap age private key → decrypt archive.
-    // Supports both new format (agePrivateKeyWrapped) and legacy format (agePrivateKey plaintext).
-    let agePrivateKey;
-    if (config.agePrivateKeyWrapped) {
-      const wrappedAgeKey = Buffer.from(config.agePrivateKeyWrapped, 'base64');
-      agePrivateKey = unwrapAgePrivateKey(wrappedAgeKey, vaultKey);
-    } else if (config.agePrivateKey) {
-      // Legacy config with plaintext age private key — accept but warn
-      agePrivateKey = config.agePrivateKey;
-    } else {
-      throw new Error('Missing age private key in config — was setup completed?');
+    if (!config.agePrivateKeyWrapped) {
+      throw new Error('Missing wrapped age private key in config — re-run lobster setup');
     }
+    const wrappedAgeKey = Buffer.from(config.agePrivateKeyWrapped, 'base64');
+    const agePrivateKey = unwrapAgePrivateKey(wrappedAgeKey, vaultKey);
 
     const tmpIdentityPath = path.join(os.tmpdir(), `lobster-identity-${Date.now()}`);
     try {

--- a/src/restore.js
+++ b/src/restore.js
@@ -10,7 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { execSync, execFileSync } from 'node:child_process';
-import { decryptArchive, derivePassphraseKey, unwrapVaultKey } from './crypto.js';
+import { decryptArchive, derivePassphraseKey, unwrapVaultKey, unwrapAgePrivateKey } from './crypto.js';
 import { substituteVariables, parseEnvFile } from './lobsterfile-env.js';
 
 /**
@@ -229,8 +229,10 @@ export async function promptForCredential(mockIO) {
  */
 export async function decryptBackup({ archivePath, credentialType, passphrase, recoveryKey, config }) {
   try {
-    // Step 1: Verify credentials by unwrapping the vault key.
-    // This proves the passphrase/recovery key is correct before we attempt decryption.
+    // Step 1: Unwrap the vault key using passphrase or recovery key.
+    // The vault key is needed to unwrap the age private key for archive decryption.
+    let vaultKey;
+
     if (credentialType === 'passphrase' && passphrase) {
       if (!config.argon2Salt || !config.vaultKeyWrappedPassphrase) {
         throw new Error('Missing Argon2 salt or wrapped vault key in config');
@@ -238,27 +240,35 @@ export async function decryptBackup({ archivePath, credentialType, passphrase, r
       const salt = Buffer.from(config.argon2Salt, 'base64');
       const wrappingKey = await derivePassphraseKey(passphrase, salt);
       const wrappedVaultKey = Buffer.from(config.vaultKeyWrappedPassphrase, 'base64');
-      await unwrapVaultKey(wrappedVaultKey, wrappingKey);
+      vaultKey = await unwrapVaultKey(wrappedVaultKey, wrappingKey);
     } else if (credentialType === 'recovery' && recoveryKey) {
       if (!config.vaultKeyWrappedRecovery) {
         throw new Error('Missing recovery-wrapped vault key in config');
       }
       const recoveryKeyBuffer = Buffer.from(recoveryKey, 'base64');
       const wrappedVaultKey = Buffer.from(config.vaultKeyWrappedRecovery, 'base64');
-      await unwrapVaultKey(wrappedVaultKey, recoveryKeyBuffer);
+      vaultKey = await unwrapVaultKey(wrappedVaultKey, recoveryKeyBuffer);
     } else {
       throw new Error('Invalid credential type or missing credentials');
     }
 
-    // Step 2: Use the age private key from config to decrypt the archive.
-    // The private key is what age needs to decrypt files encrypted to the matching public key.
-    if (!config.agePrivateKey) {
+    // Step 2: Unwrap the age private key using the vault key.
+    // Full chain: passphrase → Argon2id → unwrap vault key → unwrap age private key → decrypt archive.
+    // Supports both new format (agePrivateKeyWrapped) and legacy format (agePrivateKey plaintext).
+    let agePrivateKey;
+    if (config.agePrivateKeyWrapped) {
+      const wrappedAgeKey = Buffer.from(config.agePrivateKeyWrapped, 'base64');
+      agePrivateKey = unwrapAgePrivateKey(wrappedAgeKey, vaultKey);
+    } else if (config.agePrivateKey) {
+      // Legacy config with plaintext age private key — accept but warn
+      agePrivateKey = config.agePrivateKey;
+    } else {
       throw new Error('Missing age private key in config — was setup completed?');
     }
 
     const tmpIdentityPath = path.join(os.tmpdir(), `lobster-identity-${Date.now()}`);
     try {
-      fs.writeFileSync(tmpIdentityPath, config.agePrivateKey + '\n', { mode: 0o600 });
+      fs.writeFileSync(tmpIdentityPath, agePrivateKey + '\n', { mode: 0o600 });
 
       // Step 3: Decrypt archive using the age private key
       const result = await decryptArchive({
@@ -600,13 +610,21 @@ export async function runRestore({ config, dryRun, io, from, credentialType, pas
     config,
   });
 
-  // Step 5: Extract archive to temp directory
+  // Step 5: Write decrypted tarball to temp file, then extract
+  // decryptBackup returns { success, data: Buffer } where data is the decrypted tarball.
+  // We must extract the decrypted bytes, NOT the original .age file.
+  const decryptedPath = path.join(os.tmpdir(), `lobster-decrypted-${Date.now()}.tar.gz`);
+  fs.writeFileSync(decryptedPath, decryptResult.data);
+
   const extractDir = path.join(os.tmpdir(), `lobster-restore-${Date.now()}`);
   fs.mkdirSync(extractDir, { recursive: true });
 
   try {
     const { execFileSync } = await import('node:child_process');
-    execFileSync('tar', ['-xzf', archivePath, '-C', extractDir], { stdio: 'pipe' });
+    execFileSync('tar', ['-xzf', decryptedPath, '-C', extractDir], { stdio: 'pipe' });
+
+    // Clean up decrypted tarball immediately — contains plaintext secrets
+    try { fs.unlinkSync(decryptedPath); } catch { /* ignore */ }
 
     // Step 6: Verify integrity via checksums in meta.json
     const metaPath = path.join(extractDir, 'meta.json');
@@ -674,6 +692,8 @@ export async function runRestore({ config, dryRun, io, from, credentialType, pas
     };
 
   } finally {
+    // Clean up decrypted tarball (if extraction failed before the early cleanup)
+    try { fs.unlinkSync(decryptedPath); } catch { /* ignore */ }
     // Clean up extraction directory
     try { fs.rmSync(extractDir, { recursive: true, force: true }); } catch { /* ignore */ }
   }

--- a/src/setup.js
+++ b/src/setup.js
@@ -16,10 +16,11 @@ import {
   generateRecoveryKey as cryptoGenerateRecoveryKey,
   generateAgeKeypair,
   derivePassphraseKey,
-  wrapVaultKey
+  wrapVaultKey,
+  wrapAgePrivateKey
 } from './crypto.js';
 import { writeConfig } from './config.js';
-import { detectPlaceholders as lobsterfileDetectPlaceholders } from './lobsterfile.js';
+import { detectPlaceholders as lobsterfileDetectPlaceholders, initLobsterfile } from './lobsterfile.js';
 
 /**
  * Validate passphrase strength and confirmation
@@ -179,15 +180,18 @@ export async function runSetup(options) {
     }
   }
 
-  // 9. Write configuration
+  // 9. Wrap age private key with vault key (zero-knowledge: no plaintext key material in config)
+  const agePrivateKeyWrapped = wrapAgePrivateKey(ageKeypair.privateKey, vaultKeyBuffer);
+
+  // 10. Write configuration
   const config = {
     backupPath: resolvedBackupPath,
     vaultKeyWrappedPassphrase: vaultKeyWrappedPassphrase.toString('base64'),
     vaultKeyWrappedRecovery: vaultKeyWrappedRecovery.toString('base64'),
     argon2Salt: salt.toString('base64'),
-    // age keypair: public key is the encryption recipient, private key is for decryption
+    // age public key stored in plaintext (it's public), private key wrapped by vault key
     agePublicKey: ageKeypair.publicKey,
-    agePrivateKey: ageKeypair.privateKey,
+    agePrivateKeyWrapped: agePrivateKeyWrapped.toString('base64'),
     formatVersion: 1,
     schedule: {
       hourly: true,
@@ -198,6 +202,20 @@ export async function runSetup(options) {
   };
 
   writeConfig(config);
+
+  // 11. Initialize Lobsterfile if it doesn't exist
+  const lobsterfilePath = path.join(os.homedir(), '.openclaw', 'lobsterfile');
+  const seedPath = path.join(os.homedir(), '.openclaw', 'lobsterfile.seed');
+  const lobsterfileResult = initLobsterfile(lobsterfilePath, { seedPath });
+  
+  if (lobsterfileResult.created) {
+    io.write(`\n📝 Created Lobsterfile at ${lobsterfilePath}`);
+    if (lobsterfileResult.seeded) {
+      io.write('   (seeded from environment audit — review and refine as needed)');
+    }
+  } else {
+    io.write('\n📝 Lobsterfile already exists — not overwritten.');
+  }
 
   // Does NOT auto-modify AGENTS.md: Skills should not auto-modify core agent 
   // files. The snippet is printed; the human decides. This is a trust boundary.

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -413,6 +413,23 @@ describe('Backup Script', () => {
       expect(unlinkCalls.some((p) => typeof p === 'string' && p.includes('.tar.gz') && !p.includes('.age'))).toBe(true);
     });
 
+    it('no Lobsterfile → warns loudly (restore cannot rebuild environment)', async () => {
+      fs.existsSync.mockImplementation((p) => {
+        if (typeof p === 'string' && p.includes('lobsterfile') && !p.includes('.env') && !p.includes('.json') && !p.includes('.lock') && !p.includes('.seed')) return false;
+        if (typeof p === 'string' && p.includes('.lock')) return false;
+        return true;
+      });
+
+      const result = await runBackup({
+        config: { backupPath: backupDir },
+        dryRun: true,
+      });
+
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringMatching(/lobsterfile|rebuild|environment/i)])
+      );
+    });
+
     it('no external manifest → proceeds with warning (internal-only backup)', async () => {
       fs.existsSync.mockImplementation((p) => {
         if (typeof p === 'string' && p.includes('external-manifest')) return false;

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -85,9 +85,13 @@ describe('End-to-End Scenarios', () => {
     // wrapped keys are real base64 strings of the right length
     const wrappedKey = Buffer.from(savedConfig.vaultKeyWrappedPassphrase, 'base64');
     expect(wrappedKey.length).toBe(60); // 12 IV + 32 encrypted + 16 auth tag
-    // Config should include age keypair for archive encryption
+    // Config should include age public key and wrapped (not plaintext) private key
     expect(savedConfig.agePublicKey).toMatch(/^age1/);
-    expect(savedConfig.agePrivateKey).toMatch(/^AGE-SECRET-KEY-/);
+    expect(savedConfig.agePrivateKeyWrapped).toBeDefined();
+    expect(savedConfig.agePrivateKey).toBeUndefined(); // must NOT store plaintext
+    // Wrapped key should be a base64 string of reasonable length (12 IV + encrypted + 16 tag)
+    const wrappedAgeKey = Buffer.from(savedConfig.agePrivateKeyWrapped, 'base64');
+    expect(wrappedAgeKey.length).toBeGreaterThan(28); // minimum: 12 + 0 + 16
 
     // 2. Backup (dry run)
     const backupResult = await runBackup({

--- a/tests/lobsterfile.test.js
+++ b/tests/lobsterfile.test.js
@@ -1,6 +1,7 @@
 /**
  * Lobsterfile Parser Tests
- * Tests for reading, appending, validating, and variable detection in the Lobsterfile.
+ * Tests for reading, appending, validating, variable detection,
+ * and lifecycle (init/creation) of the Lobsterfile.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
@@ -8,8 +9,10 @@ import {
   appendToLobsterfile,
   validateLobsterfile,
   detectPlaceholders,
+  initLobsterfile,
 } from '../src/lobsterfile.js';
 import fs from 'node:fs';
+import path from 'node:path';
 import { execSync } from 'node:child_process';
 
 vi.mock('node:fs');
@@ -72,6 +75,69 @@ describe('Lobsterfile Parser', () => {
   it('reports malformed {{}} (empty placeholder) as error', () => {
     const content = 'some config with {{}} empty placeholder';
     expect(() => detectPlaceholders(content)).toThrow(/empty|malformed|invalid/i);
+  });
+
+  // --- Lobsterfile Lifecycle (initLobsterfile) ---
+  describe('Lifecycle', () => {
+    it('initLobsterfile creates file with shebang and header', () => {
+      fs.existsSync.mockReturnValue(false);
+      fs.writeFileSync.mockReturnValue(undefined);
+      fs.mkdirSync.mockReturnValue(undefined);
+
+      const result = initLobsterfile('/home/test/.openclaw/lobsterfile');
+      
+      expect(result.created).toBe(true);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/home/test/.openclaw/lobsterfile',
+        expect.stringContaining('#!/bin/bash'),
+        expect.any(Object)
+      );
+    });
+
+    it('initLobsterfile does not overwrite existing Lobsterfile', () => {
+      fs.existsSync.mockReturnValue(true); // file already exists
+
+      const result = initLobsterfile('/home/test/.openclaw/lobsterfile');
+      
+      expect(result.created).toBe(false);
+      expect(result.reason).toMatch(/already exists/i);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('initLobsterfile seeds from lobsterfile.seed if available', () => {
+      fs.existsSync.mockImplementation((p) => {
+        if (p.includes('lobsterfile.seed')) return true;
+        if (p.endsWith('lobsterfile') && !p.includes('.seed')) return false;
+        return true; // parent dir
+      });
+      fs.readFileSync.mockReturnValue(
+        '#!/bin/bash\n# lobsterfile.seed — inferred\n\n# APT packages\napt-get install -y curl\napt-get install -y caddy\n'
+      );
+      fs.writeFileSync.mockReturnValue(undefined);
+      fs.mkdirSync.mockReturnValue(undefined);
+
+      const result = initLobsterfile('/home/test/.openclaw/lobsterfile', {
+        seedPath: '/home/test/.openclaw/lobsterfile.seed',
+      });
+      
+      expect(result.created).toBe(true);
+      expect(result.seeded).toBe(true);
+      const written = fs.writeFileSync.mock.calls[0][1];
+      expect(written).toContain('#!/bin/bash');
+      expect(written).toContain('apt-get install -y curl');
+    });
+
+    it('initLobsterfile creates valid bash', () => {
+      fs.existsSync.mockReturnValue(false);
+      fs.writeFileSync.mockReturnValue(undefined);
+      fs.mkdirSync.mockReturnValue(undefined);
+
+      initLobsterfile('/home/test/.openclaw/lobsterfile');
+      
+      const written = fs.writeFileSync.mock.calls[0][1];
+      // Starts with shebang
+      expect(written.startsWith('#!/bin/bash\n')).toBe(true);
+    });
   });
 
   it('extracts complete list of all referenced variables', () => {

--- a/tests/manifest-external.test.js
+++ b/tests/manifest-external.test.js
@@ -180,6 +180,19 @@ describe('Manifest — External', () => {
       expect(entry).toContain('git checkout');
       expect(entry).toContain('main');
     });
+
+    it('quotes paths in git clone entry (handles spaces in paths)', () => {
+      const entry = generateGitCloneEntry({
+        remoteUrl: 'https://github.com/user/repo.git',
+        localPath: '/home/testuser/my projects/repo',
+        ref: 'main',
+      });
+
+      // Paths must be quoted for bash safety
+      expect(entry).toContain('"/home/testuser/my projects/repo"');
+      expect(entry).toContain('cd "/home/testuser/my projects/repo"');
+      expect(entry).toContain('"main"');
+    });
   });
 
   // --- Symlinks ---

--- a/tests/manifest-internal.test.js
+++ b/tests/manifest-internal.test.js
@@ -148,6 +148,27 @@ describe('Manifest — Internal', () => {
     expect(paths.some((p) => p.includes('secret-notes.md'))).toBe(false);
   });
 
+  it('includes workspace subdirectories (freshkit, docker, etc.) — not just top-level .md files', () => {
+    const files = [
+      `${ocDir}/workspace/SOUL.md`,
+      `${ocDir}/workspace/MEMORY.md`,
+      `${ocDir}/workspace/freshkit/server.js`,
+      `${ocDir}/workspace/freshkit/.env`,
+      `${ocDir}/workspace/freshkit/agents/index.js`,
+      `${ocDir}/workspace/docker/docker-compose.yml`,
+    ];
+    mockOCTree(files);
+
+    const manifest = generateInternalManifest(ocDir);
+    const paths = manifest.map((e) => e.path || e);
+
+    expect(paths).toEqual(expect.arrayContaining([
+      expect.stringContaining('freshkit/server.js'),
+      expect.stringContaining('freshkit/.env'),
+      expect.stringContaining('docker/docker-compose.yml'),
+    ]));
+  });
+
   it('does not traverse excluded directories (performance)', () => {
     const files = [
       `${ocDir}/workspace/SOUL.md`,

--- a/tests/restore-decrypt.test.js
+++ b/tests/restore-decrypt.test.js
@@ -17,10 +17,11 @@ vi.mock('node:child_process');
 vi.mock('../src/crypto.js', () => ({
   derivePassphraseKey: vi.fn(),
   unwrapVaultKey: vi.fn(),
+  unwrapAgePrivateKey: vi.fn(),
   decryptArchive: vi.fn(),
 }));
 
-import { derivePassphraseKey, unwrapVaultKey, decryptArchive } from '../src/crypto.js';
+import { derivePassphraseKey, unwrapVaultKey, unwrapAgePrivateKey, decryptArchive } from '../src/crypto.js';
 
 describe('Restore — Decryption', () => {
   beforeEach(() => {
@@ -144,6 +145,66 @@ describe('Restore — Decryption', () => {
         },
       })
     ).rejects.toThrow(/wrong|incorrect|failed/i);
+  });
+
+  it('wrapped age private key → unwraps via vault key before decryption', async () => {
+    const fakeDerivedKey = Buffer.alloc(32, 0xAA);
+    const fakeVaultKey = Buffer.alloc(32, 0xBB);
+
+    derivePassphraseKey.mockResolvedValue(fakeDerivedKey);
+    unwrapVaultKey.mockResolvedValue(fakeVaultKey);
+    unwrapAgePrivateKey.mockReturnValue('AGE-SECRET-KEY-1UNWRAPPED');
+    decryptArchive.mockResolvedValue(Buffer.from('decrypted-archive'));
+
+    const result = await decryptBackup({
+      archivePath: '/backups/backup.tar.gz.age',
+      credentialType: 'passphrase',
+      passphrase: 'correct-passphrase',
+      config: {
+        argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
+        vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
+        agePrivateKeyWrapped: Buffer.alloc(80, 0x04).toString('base64'),
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // Vault key should be unwrapped first, then used to unwrap age private key
+    expect(unwrapAgePrivateKey).toHaveBeenCalledWith(expect.any(Buffer), fakeVaultKey);
+    // Decryption should use the unwrapped age private key
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('lobster-identity'),
+      expect.stringContaining('AGE-SECRET-KEY-1UNWRAPPED'),
+      { mode: 0o600 }
+    );
+  });
+
+  it('legacy config with plaintext agePrivateKey still works (backward compat)', async () => {
+    const fakeVaultKey = Buffer.alloc(32, 0xBB);
+
+    derivePassphraseKey.mockResolvedValue(Buffer.alloc(32, 0xAA));
+    unwrapVaultKey.mockResolvedValue(fakeVaultKey);
+    decryptArchive.mockResolvedValue(Buffer.from('decrypted-archive'));
+
+    const result = await decryptBackup({
+      archivePath: '/backups/backup.tar.gz.age',
+      credentialType: 'passphrase',
+      passphrase: 'correct-passphrase',
+      config: {
+        argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
+        vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
+        agePrivateKey: 'AGE-SECRET-KEY-1LEGACYKEY',
+      },
+    });
+
+    expect(result.success).toBe(true);
+    // Should NOT call unwrapAgePrivateKey (legacy path)
+    expect(unwrapAgePrivateKey).not.toHaveBeenCalled();
+    // Should still use the plaintext key
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('lobster-identity'),
+      expect.stringContaining('AGE-SECRET-KEY-1LEGACYKEY'),
+      { mode: 0o600 }
+    );
   });
 
   it('corrupted archive → decryptArchive fails → clean error', async () => {

--- a/tests/restore-decrypt.test.js
+++ b/tests/restore-decrypt.test.js
@@ -43,12 +43,13 @@ describe('Restore — Decryption', () => {
     expect(mockIO.prompt).toHaveBeenCalled();
   });
 
-  it('correct passphrase → derives key via Argon2id, unwraps vault key, then decrypts with age private key', async () => {
+  it('correct passphrase → derives key via Argon2id, unwraps vault key, unwraps age key, then decrypts', async () => {
     const fakeDerivedKey = Buffer.alloc(32, 0xAA);
     const fakeVaultKey = Buffer.alloc(32, 0xBB);
 
     derivePassphraseKey.mockResolvedValue(fakeDerivedKey);
     unwrapVaultKey.mockResolvedValue(fakeVaultKey);
+    unwrapAgePrivateKey.mockReturnValue('AGE-SECRET-KEY-1TESTKEY');
     decryptArchive.mockResolvedValue(Buffer.from('decrypted-archive'));
 
     const result = await decryptBackup({
@@ -58,12 +59,12 @@ describe('Restore — Decryption', () => {
       config: {
         argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
         vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
-        agePrivateKey: 'AGE-SECRET-KEY-1TESTKEY',
+        agePrivateKeyWrapped: Buffer.alloc(80, 0x04).toString('base64'),
       },
     });
 
     expect(result.success).toBe(true);
-    // Verify passphrase was validated via the unwrap chain
+    // Verify full chain: passphrase → Argon2id → unwrap vault key → unwrap age key
     expect(derivePassphraseKey).toHaveBeenCalledWith(
       'correct-passphrase',
       expect.any(Buffer)
@@ -72,7 +73,11 @@ describe('Restore — Decryption', () => {
       expect.any(Buffer),
       fakeDerivedKey
     );
-    // Verify decryption used the age private key (written to temp file)
+    expect(unwrapAgePrivateKey).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      fakeVaultKey
+    );
+    // Verify decryption used the unwrapped age private key
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('lobster-identity'),
       expect.stringContaining('AGE-SECRET-KEY-1TESTKEY'),
@@ -85,10 +90,11 @@ describe('Restore — Decryption', () => {
     expect(fs.unlinkSync).toHaveBeenCalled();
   });
 
-  it('correct Recovery Key → unwraps vault key directly, then decrypts with age private key', async () => {
+  it('correct Recovery Key → unwraps vault key directly, unwraps age key, then decrypts', async () => {
     const fakeVaultKey = Buffer.alloc(32, 0xCC);
 
     unwrapVaultKey.mockResolvedValue(fakeVaultKey);
+    unwrapAgePrivateKey.mockReturnValue('AGE-SECRET-KEY-1RECOVERYTEST');
     decryptArchive.mockResolvedValue(Buffer.from('decrypted-archive'));
 
     const result = await decryptBackup({
@@ -97,17 +103,17 @@ describe('Restore — Decryption', () => {
       recoveryKey: Buffer.alloc(32, 0xDD).toString('base64'),
       config: {
         vaultKeyWrappedRecovery: Buffer.alloc(60, 0x03).toString('base64'),
-        agePrivateKey: 'AGE-SECRET-KEY-1RECOVERYTEST',
+        agePrivateKeyWrapped: Buffer.alloc(80, 0x04).toString('base64'),
       },
     });
 
     expect(result.success).toBe(true);
     // Recovery key path should NOT call derivePassphraseKey
     expect(derivePassphraseKey).not.toHaveBeenCalled();
-    // But should unwrap and decrypt
+    // Should unwrap vault key, then unwrap age key, then decrypt
     expect(unwrapVaultKey).toHaveBeenCalled();
+    expect(unwrapAgePrivateKey).toHaveBeenCalledWith(expect.any(Buffer), fakeVaultKey);
     expect(decryptArchive).toHaveBeenCalled();
-    // Should use age private key for decryption
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('lobster-identity'),
       expect.stringContaining('AGE-SECRET-KEY-1RECOVERYTEST'),
@@ -178,38 +184,28 @@ describe('Restore — Decryption', () => {
     );
   });
 
-  it('legacy config with plaintext agePrivateKey still works (backward compat)', async () => {
-    const fakeVaultKey = Buffer.alloc(32, 0xBB);
-
+  it('plaintext agePrivateKey (no agePrivateKeyWrapped) → rejects with clear error', async () => {
     derivePassphraseKey.mockResolvedValue(Buffer.alloc(32, 0xAA));
-    unwrapVaultKey.mockResolvedValue(fakeVaultKey);
-    decryptArchive.mockResolvedValue(Buffer.from('decrypted-archive'));
+    unwrapVaultKey.mockResolvedValue(Buffer.alloc(32, 0xBB));
 
-    const result = await decryptBackup({
-      archivePath: '/backups/backup.tar.gz.age',
-      credentialType: 'passphrase',
-      passphrase: 'correct-passphrase',
-      config: {
-        argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
-        vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
-        agePrivateKey: 'AGE-SECRET-KEY-1LEGACYKEY',
-      },
-    });
-
-    expect(result.success).toBe(true);
-    // Should NOT call unwrapAgePrivateKey (legacy path)
-    expect(unwrapAgePrivateKey).not.toHaveBeenCalled();
-    // Should still use the plaintext key
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('lobster-identity'),
-      expect.stringContaining('AGE-SECRET-KEY-1LEGACYKEY'),
-      { mode: 0o600 }
-    );
+    await expect(
+      decryptBackup({
+        archivePath: '/backups/backup.tar.gz.age',
+        credentialType: 'passphrase',
+        passphrase: 'correct-passphrase',
+        config: {
+          argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
+          vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
+          agePrivateKey: 'AGE-SECRET-KEY-1LEGACYKEY', // old format — no longer accepted
+        },
+      })
+    ).rejects.toThrow(/missing.*wrapped|re-run.*setup/i);
   });
 
   it('corrupted archive → decryptArchive fails → clean error', async () => {
     derivePassphraseKey.mockResolvedValue(Buffer.alloc(32, 0xAA));
     unwrapVaultKey.mockResolvedValue(Buffer.alloc(32, 0xBB));
+    unwrapAgePrivateKey.mockReturnValue('AGE-SECRET-KEY-1TEST');
     decryptArchive.mockImplementation(async () => { throw new Error('Failed to decrypt archive: header is invalid'); });
 
     await expect(
@@ -220,7 +216,7 @@ describe('Restore — Decryption', () => {
         config: {
           argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
           vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
-          agePrivateKey: 'AGE-SECRET-KEY-1TEST',
+          agePrivateKeyWrapped: Buffer.alloc(80, 0x04).toString('base64'),
         },
       })
     ).rejects.toThrow(/corrupt|invalid|header/i);
@@ -244,6 +240,7 @@ describe('Restore — Decryption', () => {
   it('temp identity file is cleaned up even on decryption failure', async () => {
     derivePassphraseKey.mockResolvedValue(Buffer.alloc(32, 0xAA));
     unwrapVaultKey.mockResolvedValue(Buffer.alloc(32, 0xBB));
+    unwrapAgePrivateKey.mockReturnValue('AGE-SECRET-KEY-1TEST');
     decryptArchive.mockRejectedValue(new Error('Failed to decrypt archive: decryption failed'));
 
     try {
@@ -254,7 +251,7 @@ describe('Restore — Decryption', () => {
         config: {
           argon2Salt: Buffer.alloc(32, 0x01).toString('base64'),
           vaultKeyWrappedPassphrase: Buffer.alloc(60, 0x02).toString('base64'),
-          agePrivateKey: 'AGE-SECRET-KEY-1TEST',
+          agePrivateKeyWrapped: Buffer.alloc(80, 0x04).toString('base64'),
         },
       });
     } catch {

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -411,6 +411,68 @@ describe('Setup Script', () => {
     });
   });
 
+  // --- Lobsterfile Creation ---
+  describe('Lobsterfile Creation', () => {
+    it('setup creates Lobsterfile at ~/.openclaw/lobsterfile', async () => {
+      fs.existsSync.mockReturnValue(false);
+      fs.mkdirSync.mockReturnValue(undefined);
+      fs.writeFileSync.mockReturnValue(undefined);
+
+      const mockIO = {
+        output: [],
+        write(msg) { this.output.push(msg); },
+        prompt: vi.fn().mockResolvedValue('I have saved this key'),
+      };
+
+      await runSetup({
+        io: mockIO,
+        passphrase: 'a-valid-passphrase-here-now',
+        passphraseConfirm: 'a-valid-passphrase-here-now',
+        backupPath: '/tmp/lobster-test-setup',
+        skipScan: true,
+        skipConfirmation: true,
+      });
+
+      // Lobsterfile should be created with shebang
+      const lobsterfileWrite = fs.writeFileSync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('lobsterfile') &&
+               !c[0].includes('.json') && !c[0].includes('.env') && !c[0].includes('.seed')
+      );
+      expect(lobsterfileWrite).toBeDefined();
+      expect(lobsterfileWrite[1]).toContain('#!/bin/bash');
+    });
+
+    it('setup does not overwrite existing Lobsterfile', async () => {
+      fs.existsSync.mockImplementation((p) => {
+        // Config exists = false (no reconfigure prompt), but Lobsterfile exists = true
+        if (typeof p === 'string' && p.endsWith('lobster-backup.json')) return false;
+        if (typeof p === 'string' && p.endsWith('lobsterfile') && !p.includes('.seed') && !p.includes('.env')) return true;
+        return false;
+      });
+      fs.mkdirSync.mockReturnValue(undefined);
+      fs.writeFileSync.mockReturnValue(undefined);
+
+      const mockIO = {
+        output: [],
+        write(msg) { this.output.push(msg); },
+        prompt: vi.fn().mockResolvedValue('I have saved this key'),
+      };
+
+      await runSetup({
+        io: mockIO,
+        passphrase: 'a-valid-passphrase-here-now',
+        passphraseConfirm: 'a-valid-passphrase-here-now',
+        backupPath: '/tmp/lobster-test-setup',
+        skipScan: true,
+        skipConfirmation: true,
+      });
+
+      // Should mention Lobsterfile already exists
+      const allOutput = mockIO.output.join('\n');
+      expect(allOutput).toMatch(/lobsterfile.*already|not overwritten/i);
+    });
+  });
+
   // --- Idempotency ---
   describe('Idempotency', () => {
     it('re-running setup on existing install warns and offers to reconfigure', async () => {


### PR DESCRIPTION
## Summary

Addresses all 7 open issues plus the "What Should Have Existed" gaps from the test suite postmortem.

### Issues Fixed

| Issue | Title | Fix |
|-------|-------|-----|
| #8 | Backup fails (age error) | Backup now warns loudly when no Lobsterfile exists |
| #9 | Internal manifest too narrow | `generateInternalManifest` walks full `~/.openclaw/` tree with exclusions |
| #10 | No Lobsterfile exists | `initLobsterfile()` added to setup; Lobsterfile created for Nelson's server |
| #11 | User crontab not captured | Crontab entries written to Nelson's Lobsterfile (manual agent-maintained, per spec) |
| #12 | runRestore extracts .age file | Extracts decrypted content via temp file; cleans up in finally block |
| #13 | Git clone broken for spaces | All path interpolations quoted for bash safety |
| #14 | Age private key plaintext | Private key wrapped by vault key via AES-256-GCM; **no legacy fallback** |

### Breaking change

**Configs with plaintext `agePrivateKey` are rejected.** There are no existing users or backups to protect, so backward compat was intentionally removed. Old configs get a clear error: "Missing wrapped age private key — re-run lobster setup."

### Additional improvements

- `initLobsterfile()` with seed file support (robust header stripping)
- Test: setup creates Lobsterfile with shebang
- Test: backup warns when no Lobsterfile exists
- Test: wrapped age private key decryption chain
- Test: plaintext age key is rejected (not silently accepted)
- Test: workspace subdirectories included in manifest
- Test: paths with spaces in git clone entries

### Test Results

**230/230 passing** (up from 219)