### PR TITLE
Setup prompts to add Lobsterfile instructions to AGENTS.md

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -241,28 +241,40 @@ Rules:
   record the value in lobsterfile.env
 `;
 
-  const agentsMdPath = path.join(os.homedir(), '.openclaw', 'workspace', 'AGENTS.md');
+  // Resolve workspace path from openclaw.json (same as scan.js), fall back to default
+  let workspacePath = path.join(os.homedir(), '.openclaw', 'workspace');
+  const openclawJsonPath = path.join(os.homedir(), '.openclaw', 'openclaw.json');
+  if (fs.existsSync(openclawJsonPath)) {
+    try {
+      const ocConfig = JSON.parse(fs.readFileSync(openclawJsonPath, 'utf-8'));
+      if (ocConfig.workspace) workspacePath = ocConfig.workspace;
+    } catch { /* use default */ }
+  }
+
+  const agentsMdPath = path.join(workspacePath, 'AGENTS.md');
   let agentsAlreadyHas = false;
   
-  if (fs.existsSync(agentsMdPath)) {
+  if (!fs.existsSync(agentsMdPath)) {
+    io.write(`⚠️  AGENTS.md not found at ${agentsMdPath}`);
+    io.write('   Your agent needs a Lobsterfile Maintenance section in AGENTS.md.');
+    io.write('   Add it manually once your workspace is set up:');
+    io.write('');
+    io.write(agentsSnippet);
+  } else {
     const agentsContent = fs.readFileSync(agentsMdPath, 'utf-8');
     agentsAlreadyHas = agentsContent.includes('Lobsterfile Maintenance');
   }
 
   if (agentsAlreadyHas) {
     io.write('📋 AGENTS.md already has Lobsterfile maintenance instructions.');
-  } else {
+  } else if (fs.existsSync(agentsMdPath)) {
     io.write('📋 Your AGENTS.md needs Lobsterfile maintenance instructions so your');
     io.write('   agent knows to update the Lobsterfile when it changes system state.');
     io.write('');
     const addToAgents = await io.prompt('Add Lobsterfile maintenance instructions to your AGENTS.md? [y/n]: ');
     
     if (addToAgents.toLowerCase() === 'y' || addToAgents.toLowerCase() === 'yes') {
-      if (fs.existsSync(agentsMdPath)) {
-        fs.appendFileSync(agentsMdPath, agentsSnippet);
-      } else {
-        fs.writeFileSync(agentsMdPath, agentsSnippet.trimStart());
-      }
+      fs.appendFileSync(agentsMdPath, agentsSnippet);
       io.write('✅ Added Lobsterfile maintenance section to AGENTS.md');
     } else {
       io.write('');

--- a/src/setup.js
+++ b/src/setup.js
@@ -217,31 +217,69 @@ export async function runSetup(options) {
     io.write('\n📝 Lobsterfile already exists — not overwritten.');
   }
 
-  // Does NOT auto-modify AGENTS.md: Skills should not auto-modify core agent 
-  // files. The snippet is printed; the human decides. This is a trust boundary.
   io.write('\n✅ Lobster backup has been configured successfully!');
   io.write('');
+
+  // 12. Offer to add Lobsterfile maintenance instructions to AGENTS.md
+  // Human-in-the-loop: we ask, they confirm, we edit. Respects the trust
+  // boundary (skills don't silently modify core agent files) while removing
+  // the friction of manual copy-paste.
+  const agentsSnippet = `
+
+## Lobsterfile Maintenance (lobster-backup)
+Whenever a prompt leads you to make any change to the system environment —
+installing a package, enabling a service, creating a user, modifying a config
+file outside the workspace, registering an external dependency — you MUST
+append the corresponding step(s) to the Lobsterfile before considering the
+task complete. Same obligation as updating MEMORY.md.
+
+Rules:
+- Prefix commands requiring root with \`sudo\` exactly as you ran them
+- Write every step IDEMPOTENTLY — assume the script may run on a machine
+  where some steps are already done
+- Use \`{{VARIABLE}}\` placeholders for any environment-specific values;
+  record the value in lobsterfile.env
+`;
+
+  const agentsMdPath = path.join(os.homedir(), '.openclaw', 'workspace', 'AGENTS.md');
+  let agentsAlreadyHas = false;
+  
+  if (fs.existsSync(agentsMdPath)) {
+    const agentsContent = fs.readFileSync(agentsMdPath, 'utf-8');
+    agentsAlreadyHas = agentsContent.includes('Lobsterfile Maintenance');
+  }
+
+  if (agentsAlreadyHas) {
+    io.write('📋 AGENTS.md already has Lobsterfile maintenance instructions.');
+  } else {
+    io.write('📋 Your AGENTS.md needs Lobsterfile maintenance instructions so your');
+    io.write('   agent knows to update the Lobsterfile when it changes system state.');
+    io.write('');
+    const addToAgents = await io.prompt('Add Lobsterfile maintenance instructions to your AGENTS.md? [y/n]: ');
+    
+    if (addToAgents.toLowerCase() === 'y' || addToAgents.toLowerCase() === 'yes') {
+      if (fs.existsSync(agentsMdPath)) {
+        fs.appendFileSync(agentsMdPath, agentsSnippet);
+      } else {
+        fs.writeFileSync(agentsMdPath, agentsSnippet.trimStart());
+      }
+      io.write('✅ Added Lobsterfile maintenance section to AGENTS.md');
+    } else {
+      io.write('');
+      io.write('To add it manually later, paste this into your AGENTS.md:');
+      io.write('');
+      io.write(agentsSnippet);
+    }
+  }
+
+  io.write('');
   io.write('╔══════════════════════════════════════════════════════════════════╗');
-  io.write('║                     ⚠️  REQUIRED NEXT STEPS                     ║');
+  io.write('║                       📋  NEXT STEP                             ║');
   io.write('╠══════════════════════════════════════════════════════════════════╣');
   io.write('║                                                                  ║');
-  io.write('║  1. Run `lobster scan --register` to discover and register       ║');
-  io.write('║     system files (Caddy configs, systemd units, etc.)            ║');
-  io.write('║     Without this, backups only include ~/.openclaw/              ║');
-  io.write('║                                                                  ║');
-  io.write('║  2. Add this to your AGENTS.md:                                  ║');
-  io.write('║                                                                  ║');
-  io.write('║     ## Lobsterfile Maintenance (lobster-backup)                  ║');
-  io.write('║     Whenever a prompt leads you to make any change to the        ║');
-  io.write('║     system environment — installing a package, enabling a        ║');
-  io.write('║     service, creating a user, modifying a config file outside    ║');
-  io.write('║     the workspace, registering an external dependency — you      ║');
-  io.write('║     MUST append the corresponding step(s) to the Lobsterfile     ║');
-  io.write('║     before considering the task complete. Same obligation as     ║');
-  io.write('║     updating MEMORY.md.                                          ║');
-  io.write('║                                                                  ║');
-  io.write('║  Backups without scan = workspace only. No system configs.       ║');
-  io.write('║  Backups without AGENTS.md update = Lobsterfile won\'t grow.     ║');
+  io.write('║  Run `lobster scan --register` to discover and register          ║');
+  io.write('║  system files (Caddy configs, systemd units, etc.)               ║');
+  io.write('║  Without this, backups only include ~/.openclaw/                 ║');
   io.write('║                                                                  ║');
   io.write('╚══════════════════════════════════════════════════════════════════╝');
   io.write('');

--- a/tests/setup.test.js
+++ b/tests/setup.test.js
@@ -314,7 +314,8 @@ describe('Setup Script', () => {
         write(msg) { this.output.push(msg); },
         prompt: vi.fn()
           .mockResolvedValueOnce('I have saved this key')
-          .mockResolvedValueOnce('y'),
+          .mockResolvedValueOnce('y')
+          .mockResolvedValueOnce('n'),  // AGENTS.md prompt
       };
 
       fs.existsSync.mockReturnValue(false);
@@ -379,18 +380,98 @@ describe('Setup Script', () => {
       }
     });
 
-    it('prints AGENTS.md snippet (does NOT auto-modify AGENTS.md)', async () => {
+    it('offers to add Lobsterfile instructions to AGENTS.md (writes on confirm)', async () => {
+      fs.existsSync.mockImplementation((p) => {
+        if (typeof p === 'string' && p.includes('AGENTS.md')) return true;
+        if (typeof p === 'string' && p.includes('lobster-backup.json')) return false;
+        return false;
+      });
+      fs.readFileSync.mockReturnValue('# AGENTS.md\n'); // no existing Lobsterfile section
+      fs.mkdirSync.mockReturnValue(undefined);
+      fs.writeFileSync.mockReturnValue(undefined);
+      fs.appendFileSync.mockReturnValue(undefined);
+
+      const mockIO = {
+        output: [],
+        write(msg) { this.output.push(msg); },
+        prompt: vi.fn()
+          .mockResolvedValueOnce('I have saved this key')  // recovery key ack
+          .mockResolvedValueOnce('y')                       // activate
+          .mockResolvedValueOnce('y'),                      // add to AGENTS.md
+      };
+
+      await runSetup({
+        io: mockIO,
+        passphrase: 'a-valid-passphrase-here-now',
+        passphraseConfirm: 'a-valid-passphrase-here-now',
+        backupPath: tmpDir,
+        skipScan: true,
+      });
+
+      // Should have appended Lobsterfile Maintenance to AGENTS.md
+      const agentsAppend = fs.appendFileSync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('AGENTS.md')
+      );
+      expect(agentsAppend).toBeDefined();
+      expect(agentsAppend[1]).toMatch(/Lobsterfile Maintenance/);
+    });
+
+    it('does not modify AGENTS.md when user declines', async () => {
+      fs.existsSync.mockImplementation((p) => {
+        if (typeof p === 'string' && p.includes('AGENTS.md')) return true;
+        if (typeof p === 'string' && p.includes('lobster-backup.json')) return false;
+        return false;
+      });
+      fs.readFileSync.mockReturnValue('# AGENTS.md\n');
+      fs.mkdirSync.mockReturnValue(undefined);
+      fs.writeFileSync.mockReturnValue(undefined);
+      fs.appendFileSync.mockReturnValue(undefined);
+
+      const mockIO = {
+        output: [],
+        write(msg) { this.output.push(msg); },
+        prompt: vi.fn()
+          .mockResolvedValueOnce('I have saved this key')
+          .mockResolvedValueOnce('y')
+          .mockResolvedValueOnce('n'),                      // decline AGENTS.md
+      };
+
+      await runSetup({
+        io: mockIO,
+        passphrase: 'a-valid-passphrase-here-now',
+        passphraseConfirm: 'a-valid-passphrase-here-now',
+        backupPath: tmpDir,
+        skipScan: true,
+      });
+
+      // Should NOT have written to AGENTS.md
+      const agentsAppend = fs.appendFileSync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('AGENTS.md')
+      );
+      expect(agentsAppend).toBeUndefined();
+      // But should print the snippet for manual addition
+      const allOutput = mockIO.output.join('\n');
+      expect(allOutput).toMatch(/Lobsterfile Maintenance/);
+    });
+
+    it('skips AGENTS.md prompt if section already exists', async () => {
+      fs.existsSync.mockImplementation((p) => {
+        if (typeof p === 'string' && p.includes('AGENTS.md')) return true;
+        if (typeof p === 'string' && p.includes('lobster-backup.json')) return false;
+        return false;
+      });
+      fs.readFileSync.mockReturnValue('# AGENTS.md\n## Lobsterfile Maintenance (lobster-backup)\n');
+      fs.mkdirSync.mockReturnValue(undefined);
+      fs.writeFileSync.mockReturnValue(undefined);
+
       const mockIO = {
         output: [],
         write(msg) { this.output.push(msg); },
         prompt: vi.fn()
           .mockResolvedValueOnce('I have saved this key')
           .mockResolvedValueOnce('y'),
+          // No third prompt — should not ask about AGENTS.md
       };
-
-      fs.existsSync.mockReturnValue(false);
-      fs.mkdirSync.mockReturnValue(undefined);
-      fs.writeFileSync.mockReturnValue(undefined);
 
       await runSetup({
         io: mockIO,
@@ -401,13 +482,7 @@ describe('Setup Script', () => {
       });
 
       const allOutput = mockIO.output.join('\n');
-      expect(allOutput).toMatch(/AGENTS\.md|Lobsterfile Maintenance/i);
-
-      // Must NOT write to AGENTS.md
-      const agentsWrite = fs.writeFileSync.mock.calls.find(
-        (c) => c[0].includes('AGENTS.md')
-      );
-      expect(agentsWrite).toBeUndefined();
+      expect(allOutput).toMatch(/already has/i);
     });
   });
 


### PR DESCRIPTION
Instead of printing a wall of text in a box and hoping the user copy-pastes it, setup now asks:

> `Add Lobsterfile maintenance instructions to your AGENTS.md? [y/n]:`

- **Yes** → appends the section to AGENTS.md
- **No** → prints the snippet for manual addition
- **Already exists** → skips the prompt entirely (idempotent)

Still human-in-the-loop (respects the trust boundary concern from the spec), but removes the friction that David flagged during setup.

Also simplified the 'next steps' box — scan is the only remaining manual step.

232/232 tests passing.